### PR TITLE
Patch/odin associations

### DIFF
--- a/app/adapters/odin-resource.js
+++ b/app/adapters/odin-resource.js
@@ -1,0 +1,10 @@
+import ApplicationAdapter from 'ghost-admin/adapters/application';
+import { underscore } from '@ember/string';
+import { pluralize } from 'ember-inflector';
+
+export default ApplicationAdapter.extend({
+  pathForType: function(modelName) {
+    var underscored = underscore(modelName);
+    return pluralize(underscored);
+  }
+});

--- a/app/components/gh-psm-associations-input.js
+++ b/app/components/gh-psm-associations-input.js
@@ -7,6 +7,26 @@ import _ from 'lodash/lodash';
 const brokkUrl = 'https://vqs32o851c.execute-api.us-east-1.amazonaws.com/production/';
 
 export default Component.extend({
+    init(){
+        this._super(...arguments);
+        if(!this.postId){
+            return;
+        }
+        const url = this.url+`?filter=post_id%3A${this.postId}`;
+        this.ajax.request(url).then((response) => {
+            const associations = response.odin_associations.map(el => {
+                return {
+                    sigla: el.label,
+                    id: parseInt(el.resource_id),
+                    module_id: el.module_id,
+                    association_id: el.id
+                }
+            });
+            console.log(associations);
+            this.set('selectedExaminingBoards', associations.filter(a => a.module_id == this.get('examiningBoard').id));
+            this.set('selectedInstitutes', associations.filter(a => a.module_id == this.get('institute').id));
+        });
+    },
     url: `${ghostPaths().apiRoot}/odin_associations`,
     ajax: service(),
     examiningBoards: null,
@@ -96,7 +116,8 @@ export default Component.extend({
             odin_associations: [{
                 post_id: this.postId,
                 module_id: module.id,
-                resource_id: resource.id
+                resource_id: resource.id,
+                label: resource.sigla
             }]
         });
     },
@@ -114,7 +135,7 @@ export default Component.extend({
         });
     },
     deleteAssociation(id) {
-        let url = this.url+`/${id}`;
+        const url = this.url+`/${id}`;
         return this.ajax.del(url);
     }
 });

--- a/app/components/gh-psm-associations-input.js
+++ b/app/components/gh-psm-associations-input.js
@@ -1,36 +1,45 @@
 import Ember from 'ember';
-import {computed} from '@ember/object';
-
+const brokkUrl = 'https://vqs32o851c.execute-api.us-east-1.amazonaws.com/production/';
 export default Ember.Component.extend({
-  selectedModule: null,
-  selectedRecord: null,
-  modules: [
-    {
+  examiningBoards: null,
+  selectedExaminingBoards: [],
+  examiningBoardsIds: [],
+  institutes: null,
+  selectedInstitutes: [],
+  institutesIds: [],
+  examiningBoard: {
       id: 4,
-      name: 'Banca'
+      name: 'Examining Board',
+      getFunction: 'getExaminingBoards'
     },
-    {
-      id: 6,
-      name: 'Cargo'
-    },
-    {
+  institute: {
       id: 11,
-      name: 'Instituto'
-    }
-  ],
-  moduleOptions: [],
-  options: {
-    4: ['A', 'B', 'C'],
-    6: ['1', '2', '3'],
-    11: ['X', 'Y', 'Z']
-  },
-  actions: {
-    setModule: function(selected) {
-      this.set('selectedModule', selected)
-      this.set('moduleOptions', this.get('options')[selected.id])
+      name: 'Institute',
+      getFunction: 'getInstitutes'
     },
-    isModulePresent: function() {
-      return selectedModule !== null;
+  actions: {
+    selectExaminingBoard(selected){
+      selected = selected.reduce((unique, element) => {
+        return unique.map(e => e.id).includes(element.id) ? unique : [...unique, element];
+      }, []);
+      this.set('selectedExaminingBoards', selected);
+    },
+    selectInstitute(selected){
+      selected = [...new Set(selected)];
+      this.set('selectedInstitutes', this.selectedInstitutes.concat(selected));
+      this.set('institutesIds', this.institutesIds.concat([selected[0].id]));
+    },
+    getExaminingBoards() {
+      if(!this.examiningBoards){
+        let collection = fetch(brokkUrl + 'product/1/examining_boards').then(response => response.json()).then(data => data);
+        this.set('examiningBoards', collection);
+      }
+    },
+    getInstitutes() {
+      if(!this.institutes){
+        let collection = fetch(brokkUrl + 'product/1/institutes').then(response => response.json()).then(data => data);
+        this.set('institutes', collection);
+      }
     }
   }
 });

--- a/app/components/gh-psm-associations-input.js
+++ b/app/components/gh-psm-associations-input.js
@@ -1,46 +1,46 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 const brokkUrl = 'https://vqs32o851c.execute-api.us-east-1.amazonaws.com/production/';
-export default Ember.Component.extend({
-  examiningBoards: null,
-  selectedExaminingBoards: [],
-  examiningBoardsIds: [],
-  institutes: null,
-  selectedInstitutes: [],
-  institutesIds: [],
-  examiningBoard: {
-      id: 4,
-      name: 'Examining Boards',
-      getFunction: 'getExaminingBoards'
+export default Component.extend({
+    examiningBoards: null,
+    selectedExaminingBoards: [],
+    examiningBoardsIds: [],
+    institutes: null,
+    selectedInstitutes: [],
+    institutesIds: [],
+    examiningBoard: {
+        id: 4,
+        name: 'Examining Boards',
+        getFunction: 'getExaminingBoards'
     },
-  institute: {
-      id: 11,
-      name: 'Institutes',
-      getFunction: 'getInstitutes'
+    institute: {
+        id: 11,
+        name: 'Institutes',
+        getFunction: 'getInstitutes'
     },
-  actions: {
-    selectExaminingBoard(selected){
-      selected = selected.reduce((unique, element) => {
-        return unique.map(e => e.id).includes(element.id) ? unique : [...unique, element];
-      }, []);
-      this.set('selectedExaminingBoards', selected);
-    },
-    selectInstitute(selected){
-      selected = selected.reduce((unique, element) => {
-        return unique.map(e => e.id).includes(element.id) ? unique : [...unique, element];
-      }, []);
-      this.set('selectedInstitutes', selected);
-    },
-    getExaminingBoards() {
-      if(!this.examiningBoards){
-        let collection = fetch(brokkUrl + 'product/1/examining_boards').then(response => response.json()).then(data => data);
-        this.set('examiningBoards', collection);
-      }
-    },
-    getInstitutes() {
-      if(!this.institutes){
-        let collection = fetch(brokkUrl + 'product/1/institutes').then(response => response.json()).then(data => data);
-        this.set('institutes', collection);
-      }
+    actions: {
+        selectExaminingBoard(selected) {
+            selected = selected.reduce((unique, element) => {
+                return unique.map(e => e.id).includes(element.id) ? unique : [...unique, element];
+            }, []);
+            this.set('selectedExaminingBoards', selected);
+        },
+        selectInstitute(selected) {
+            selected = selected.reduce((unique, element) => {
+                return unique.map(e => e.id).includes(element.id) ? unique : [...unique, element];
+            }, []);
+            this.set('selectedInstitutes', selected);
+        },
+        getExaminingBoards() {
+            if (!this.examiningBoards) {
+                let collection = fetch(brokkUrl + 'product/1/examining_boards').then(response => response.json()).then(data => data);
+                this.set('examiningBoards', collection);
+            }
+        },
+        getInstitutes() {
+            if (!this.institutes) {
+                let collection = fetch(brokkUrl + 'product/1/institutes').then(response => response.json()).then(data => data);
+                this.set('institutes', collection);
+            }
+        }
     }
-  }
 });

--- a/app/components/gh-psm-associations-input.js
+++ b/app/components/gh-psm-associations-input.js
@@ -10,23 +10,16 @@ export default Component.extend({
     store: service(),
     init(){
         this._super(...arguments);
-        if(!this.postId){
-            return;
-        }
         this.store.query('odin-resource', {limit: 'all'});
         this.set('availableResources', this.store.peekAll('odin-resource'));
         this.set('selectedExaminingBoards', this.get('selectedAssociations').filter((resource) => resource.moduleId == this.get('examiningBoard').id));
         this.set('selectedInstitutes', this.get('selectedAssociations').filter((resource) => resource.moduleId == this.get('institute').id));
     },
-    url: `${ghostPaths().apiRoot}/odin_associations`,
-    ajax: service(),
     availableResources: null,
     examiningBoards: null,
     selectedExaminingBoards: null,
-    examiningBoardsIds: [],
     institutes: null,
     selectedInstitutes: null,
-    institutesIds: [],
     examiningBoard: {
         id: 4,
         name: 'Examining Boards',

--- a/app/components/gh-psm-associations-input.js
+++ b/app/components/gh-psm-associations-input.js
@@ -22,7 +22,6 @@ export default Component.extend({
                     association_id: el.id
                 }
             });
-            console.log(associations);
             this.set('selectedExaminingBoards', associations.filter(a => a.module_id == this.get('examiningBoard').id));
             this.set('selectedInstitutes', associations.filter(a => a.module_id == this.get('institute').id));
         });

--- a/app/components/gh-psm-associations-input.js
+++ b/app/components/gh-psm-associations-input.js
@@ -1,0 +1,36 @@
+import Ember from 'ember';
+import {computed} from '@ember/object';
+
+export default Ember.Component.extend({
+  selectedModule: null,
+  selectedRecord: null,
+  modules: [
+    {
+      id: 4,
+      name: 'Banca'
+    },
+    {
+      id: 6,
+      name: 'Cargo'
+    },
+    {
+      id: 11,
+      name: 'Instituto'
+    }
+  ],
+  moduleOptions: [],
+  options: {
+    4: ['A', 'B', 'C'],
+    6: ['1', '2', '3'],
+    11: ['X', 'Y', 'Z']
+  },
+  actions: {
+    setModule: function(selected) {
+      this.set('selectedModule', selected)
+      this.set('moduleOptions', this.get('options')[selected.id])
+    },
+    isModulePresent: function() {
+      return selectedModule !== null;
+    }
+  }
+});

--- a/app/components/gh-psm-associations-input.js
+++ b/app/components/gh-psm-associations-input.js
@@ -7,32 +7,25 @@ import _ from 'lodash/lodash';
 const brokkUrl = 'https://vqs32o851c.execute-api.us-east-1.amazonaws.com/production/';
 
 export default Component.extend({
+    store: service(),
     init(){
         this._super(...arguments);
         if(!this.postId){
             return;
         }
-        const url = this.url+`?filter=post_id%3A${this.postId}`;
-        this.ajax.request(url).then((response) => {
-            const associations = response.odin_associations.map(el => {
-                return {
-                    sigla: el.label,
-                    id: parseInt(el.resource_id),
-                    module_id: el.module_id,
-                    association_id: el.id
-                }
-            });
-            this.set('selectedExaminingBoards', associations.filter(a => a.module_id == this.get('examiningBoard').id));
-            this.set('selectedInstitutes', associations.filter(a => a.module_id == this.get('institute').id));
-        });
+        this.store.query('odin-resource', {limit: 'all'});
+        this.set('availableResources', this.store.peekAll('odin-resource'));
+        this.set('selectedExaminingBoards', this.get('selectedAssociations').filter((resource) => resource.moduleId == this.get('examiningBoard').id));
+        this.set('selectedInstitutes', this.get('selectedAssociations').filter((resource) => resource.moduleId == this.get('institute').id));
     },
     url: `${ghostPaths().apiRoot}/odin_associations`,
     ajax: service(),
+    availableResources: null,
     examiningBoards: null,
-    selectedExaminingBoards: [],
+    selectedExaminingBoards: null,
     examiningBoardsIds: [],
     institutes: null,
-    selectedInstitutes: [],
+    selectedInstitutes: null,
     institutesIds: [],
     examiningBoard: {
         id: 4,
@@ -46,51 +39,59 @@ export default Component.extend({
     },
     actions: {
         selectExaminingBoard(selected) {
-            selected = selected.reduce((unique, element) => {
-                if(unique.map(e => e.id).includes(element.id)){
-                    return unique;
-                }
-                return [...unique, element];
-            }, []);
             let previous = this.get('selectedExaminingBoards');
             let next = selected
             if(previous.length > next.length){
-                let diff = this.compareState(previous, next);
-                if(!diff) return;
-                this.deleteAssociation(diff.association_id);
                 this.set('selectedExaminingBoards', selected);
+                this.set('selectedAssociations', selected.concat(this.get('selectedInstitutes')));
             }else{
-                let diff = this.compareState(next, previous);
-                if(!diff) return;
-                let data = this.buildData(this.get('examiningBoard'), selected[selected.length-1]);
-                this.createAssociation(data).then((id) => {
-                    selected[selected.length-1].association_id = id;
-                    this.set('selectedExaminingBoards', selected);
+                let added = selected[selected.length-1];
+                let availableResources = this.get('availableResources');
+                let duplicate = previous.find((resource) => {
+                    return resource.resourceId == added.id && resource.moduleId == this.get('examiningBoard').id && resource.productId == 1;
                 });
+                if(duplicate) return;
+                let resourceToAdd = availableResources.filter((resource) => {
+                    added.id == resource.resourceId && this.get('examiningBoard').id == resource.moduleId && resource.productId == 1;
+                });
+                if(_.isEmpty(resourceToAdd)){
+                    resourceToAdd = this.store.createRecord('odin-resource', {
+                        moduleId: this.get('examiningBoard').id,
+                        resourceId: added.id.toString(),
+                        productId: '1',
+                        label: added.sigla
+                    });
+                }
+                this.get('selectedAssociations').pushObject(resourceToAdd);
+                this.get('selectedExaminingBoards').pushObject(resourceToAdd);
             }
         },
         selectInstitute(selected) {
-            selected = selected.reduce((unique, element) => {
-                if(unique.map(e => e.id).includes(element.id)){
-                    return unique;
-                }
-                return [...unique, element];
-            }, []);
             let previous = this.get('selectedInstitutes');
             let next = selected
             if(previous.length > next.length){
-                let diff = this.compareState(previous, next);
-                if(!diff) return;
-                this.deleteAssociation(diff.association_id);
                 this.set('selectedInstitutes', selected);
+                this.set('selectedAssociations', selected.concat(this.get('selectedExaminingBoards')));
             }else{
-                let diff = this.compareState(next, previous);
-                if(!diff) return;
-                let data = this.buildData(this.get('institute'), selected[selected.length-1]);
-                this.createAssociation(data).then((id) => {
-                    selected[selected.length-1].association_id = id;
-                    this.set('selectedInstitutes', selected);
+                let added = selected[selected.length-1];
+                let availableResources = this.get('availableResources');
+                let duplicate = previous.find((resource) => {
+                    return resource.resourceId == added.id && resource.moduleId == this.get('institute').id && resource.productId == 1;
                 });
+                if(duplicate) return;
+                let resourceToAdd = availableResources.filter((resource) => {
+                    added.id == resource.resourceId && this.get('institute').id == resource.moduleId && resource.productId == 1;
+                });
+                if(_.isEmpty(resourceToAdd)){
+                    resourceToAdd = this.store.createRecord('odin-resource', {
+                        moduleId: this.get('institute').id,
+                        resourceId: added.id.toString(),
+                        productId: '1',
+                        label: added.sigla
+                    });
+                }
+                this.get('selectedAssociations').pushObject(resourceToAdd);
+                this.get('selectedInstitutes').pushObject(resourceToAdd);
             }
         },
         getExaminingBoards() {
@@ -105,36 +106,5 @@ export default Component.extend({
                 this.set('institutes', collection);
             }
         }
-    },
-    compareState(previous, next){
-        let diff = _.differenceBy(previous, next, 'id');
-        return diff[0];
-    },
-    buildData(module, resource) {
-        return JSON.stringify({
-            odin_associations: [{
-                post_id: this.postId,
-                module_id: module.id,
-                resource_id: resource.id,
-                label: resource.sigla
-            }]
-        });
-    },
-    createAssociation(data) {
-        return this.ajax.post(this.url, {
-            data: data,
-            processData: false,
-            contentType: 'application/json',
-            dataType: 'text',
-            xhr: () => {
-                return new window.XMLHttpRequest();
-            }
-        }).then((response) => {
-            return JSON.parse(response).odin_associations[0].id;
-        });
-    },
-    deleteAssociation(id) {
-        const url = this.url+`/${id}`;
-        return this.ajax.del(url);
     }
 });

--- a/app/components/gh-psm-associations-input.js
+++ b/app/components/gh-psm-associations-input.js
@@ -1,6 +1,14 @@
 import Component from '@ember/component';
+import ghostPaths from 'ghost-admin/utils/ghost-paths';
+import {inject as service} from '@ember/service';
+
+import _ from 'lodash/lodash';
+
 const brokkUrl = 'https://vqs32o851c.execute-api.us-east-1.amazonaws.com/production/';
+
 export default Component.extend({
+    url: `${ghostPaths().apiRoot}/odin_associations`,
+    ajax: service(),
     examiningBoards: null,
     selectedExaminingBoards: [],
     examiningBoardsIds: [],
@@ -20,15 +28,51 @@ export default Component.extend({
     actions: {
         selectExaminingBoard(selected) {
             selected = selected.reduce((unique, element) => {
-                return unique.map(e => e.id).includes(element.id) ? unique : [...unique, element];
+                if(unique.map(e => e.id).includes(element.id)){
+                    return unique;
+                }
+                return [...unique, element];
             }, []);
-            this.set('selectedExaminingBoards', selected);
+            let previous = this.get('selectedExaminingBoards');
+            let next = selected
+            if(previous.length > next.length){
+                let diff = this.compareState(previous, next);
+                if(!diff) return;
+                this.deleteAssociation(diff.association_id);
+                this.set('selectedExaminingBoards', selected);
+            }else{
+                let diff = this.compareState(next, previous);
+                if(!diff) return;
+                let data = this.buildData(this.get('examiningBoard'), selected[selected.length-1]);
+                this.createAssociation(data).then((id) => {
+                    selected[selected.length-1].association_id = id;
+                    this.set('selectedExaminingBoards', selected);
+                });
+            }
         },
         selectInstitute(selected) {
             selected = selected.reduce((unique, element) => {
-                return unique.map(e => e.id).includes(element.id) ? unique : [...unique, element];
+                if(unique.map(e => e.id).includes(element.id)){
+                    return unique;
+                }
+                return [...unique, element];
             }, []);
-            this.set('selectedInstitutes', selected);
+            let previous = this.get('selectedInstitutes');
+            let next = selected
+            if(previous.length > next.length){
+                let diff = this.compareState(previous, next);
+                if(!diff) return;
+                this.deleteAssociation(diff.association_id);
+                this.set('selectedInstitutes', selected);
+            }else{
+                let diff = this.compareState(next, previous);
+                if(!diff) return;
+                let data = this.buildData(this.get('institute'), selected[selected.length-1]);
+                this.createAssociation(data).then((id) => {
+                    selected[selected.length-1].association_id = id;
+                    this.set('selectedInstitutes', selected);
+                });
+            }
         },
         getExaminingBoards() {
             if (!this.examiningBoards) {
@@ -42,5 +86,35 @@ export default Component.extend({
                 this.set('institutes', collection);
             }
         }
+    },
+    compareState(previous, next){
+        let diff = _.differenceBy(previous, next, 'id');
+        return diff[0];
+    },
+    buildData(module, resource) {
+        return JSON.stringify({
+            odin_associations: [{
+                post_id: this.postId,
+                module_id: module.id,
+                resource_id: resource.id
+            }]
+        });
+    },
+    createAssociation(data) {
+        return this.ajax.post(this.url, {
+            data: data,
+            processData: false,
+            contentType: 'application/json',
+            dataType: 'text',
+            xhr: () => {
+                return new window.XMLHttpRequest();
+            }
+        }).then((response) => {
+            return JSON.parse(response).odin_associations[0].id;
+        });
+    },
+    deleteAssociation(id) {
+        let url = this.url+`/${id}`;
+        return this.ajax.del(url);
     }
 });

--- a/app/components/gh-psm-associations-input.js
+++ b/app/components/gh-psm-associations-input.js
@@ -9,12 +9,12 @@ export default Ember.Component.extend({
   institutesIds: [],
   examiningBoard: {
       id: 4,
-      name: 'Examining Board',
+      name: 'Examining Boards',
       getFunction: 'getExaminingBoards'
     },
   institute: {
       id: 11,
-      name: 'Institute',
+      name: 'Institutes',
       getFunction: 'getInstitutes'
     },
   actions: {
@@ -25,9 +25,10 @@ export default Ember.Component.extend({
       this.set('selectedExaminingBoards', selected);
     },
     selectInstitute(selected){
-      selected = [...new Set(selected)];
-      this.set('selectedInstitutes', this.selectedInstitutes.concat(selected));
-      this.set('institutesIds', this.institutesIds.concat([selected[0].id]));
+      selected = selected.reduce((unique, element) => {
+        return unique.map(e => e.id).includes(element.id) ? unique : [...unique, element];
+      }, []);
+      this.set('selectedInstitutes', selected);
     },
     getExaminingBoards() {
       if(!this.examiningBoards){

--- a/app/models/odin-resource.js
+++ b/app/models/odin-resource.js
@@ -1,0 +1,9 @@
+import Model from 'ember-data/model';
+import attr from 'ember-data/attr';
+
+export default Model.extend({
+  moduleId: attr('string'),
+  resourceId: attr('string'),
+  productId: attr('string'),
+  label: attr('string')
+});

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -116,7 +116,10 @@ export default Model.extend(Comparable, ValidationEngine, {
         embedded: 'always',
         async: false
     }),
-
+    odinResources: hasMany('odin_resource', {
+        embedded: 'always',
+        async: false
+    }),
     primaryAuthor: computed('authors.[]', function () {
         return this.get('authors.firstObject');
     }),

--- a/app/serializers/post.js
+++ b/app/serializers/post.js
@@ -8,6 +8,7 @@ export default ApplicationSerializer.extend(EmbeddedRecordsMixin, {
     attrs: {
         authors: {embedded: 'always'},
         tags: {embedded: 'always'},
+        odinResources: {embedded: 'always'},
         publishedAtUTC: {key: 'published_at'},
         createdAtUTC: {key: 'created_at'},
         updatedAtUTC: {key: 'updated_at'}

--- a/app/templates/components/gh-post-settings-menu.hbs
+++ b/app/templates/components/gh-post-settings-menu.hbs
@@ -100,9 +100,9 @@
                 {{!-- New Odin Associations --}}
                 {{#unless session.user.isAuthorOrContributor}}
                     {{#gh-form-group class="for-select" errors=post.errors hasValidated=post.hasValidated property="associations" data-test-input="associations"}}
-                        <label for="author-list">Associations</label>
-                        {{gh-psm-associations-input selectedAuthors=post.authors updateAuthors=(action "changeAuthors") triggerId="author-list"}}
-                        {{gh-error-message errors=post.errors property="authors" data-test-error="authors"}}
+                        <label for="associations-list">Associations</label>
+                        {{gh-psm-associations-input selectedAuthors=post.authors updateAuthors=(action "changeAuthors") triggerId="associations-list"}}
+                        {{gh-error-message errors=post.errors property="associations" data-test-error="associations"}}
                     {{/gh-form-group}}
                 {{/unless}}
 

--- a/app/templates/components/gh-post-settings-menu.hbs
+++ b/app/templates/components/gh-post-settings-menu.hbs
@@ -101,7 +101,7 @@
                 {{#unless session.user.isAuthorOrContributor}}
                     {{#gh-form-group class="for-select" errors=post.errors hasValidated=post.hasValidated property="associations" data-test-input="associations"}}
                         <label for="associations-list">Associations</label>
-                        {{gh-psm-associations-input selectedAuthors=post.authors updateAuthors=(action "changeAuthors") triggerId="associations-list"}}
+                        {{gh-psm-associations-input selectedAssociations=post.associations postId=post.id triggerId="associations-list"}}
                         {{gh-error-message errors=post.errors property="associations" data-test-error="associations"}}
                     {{/gh-form-group}}
                 {{/unless}}

--- a/app/templates/components/gh-post-settings-menu.hbs
+++ b/app/templates/components/gh-post-settings-menu.hbs
@@ -97,6 +97,15 @@
                     {{/gh-form-group}}
                 {{/unless}}
 
+                {{!-- New Odin Associations --}}
+                {{#unless session.user.isAuthorOrContributor}}
+                    {{#gh-form-group class="for-select" errors=post.errors hasValidated=post.hasValidated property="associations" data-test-input="associations"}}
+                        <label for="author-list">Associations</label>
+                        {{gh-psm-associations-input selectedAuthors=post.authors updateAuthors=(action "changeAuthors") triggerId="author-list"}}
+                        {{gh-error-message errors=post.errors property="authors" data-test-error="authors"}}
+                    {{/gh-form-group}}
+                {{/unless}}
+
                 <ul class="nav-list nav-list-block">
                     <li class="nav-list-item" {{action "showSubview" "meta-data"}} data-test-button="meta-data">
                         <button type="button">

--- a/app/templates/components/gh-post-settings-menu.hbs
+++ b/app/templates/components/gh-post-settings-menu.hbs
@@ -101,7 +101,7 @@
                 {{#unless session.user.isAuthorOrContributor}}
                     {{#gh-form-group class="for-select" errors=post.errors hasValidated=post.hasValidated property="associations" data-test-input="associations"}}
                         <label for="associations-list">Associations</label>
-                        {{gh-psm-associations-input selectedAssociations=post.associations postId=post.id triggerId="associations-list"}}
+                        {{gh-psm-associations-input selectedAssociations=post.odinResources postId=post.id triggerId="associations-list"}}
                         {{gh-error-message errors=post.errors property="associations" data-test-error="associations"}}
                     {{/gh-form-group}}
                 {{/unless}}

--- a/app/templates/components/gh-psm-associations-input.hbs
+++ b/app/templates/components/gh-psm-associations-input.hbs
@@ -8,7 +8,7 @@ renderInPlace=true
 searchField="sigla"
 selected=selectedExaminingBoards
 as |record| }}
-{{record.sigla}}
+  {{if record.label record.label record.sigla}}
 {{/gh-token-input/select-multiple}}
 
 <b>{{institute.name}}</b>
@@ -21,5 +21,5 @@ renderInPlace=true
 searchField="sigla"
 selected=selectedInstitutes
 as |record| }}
-{{record.sigla}}
+  {{if record.label record.label record.sigla}}
 {{/gh-token-input/select-multiple}}

--- a/app/templates/components/gh-psm-associations-input.hbs
+++ b/app/templates/components/gh-psm-associations-input.hbs
@@ -1,20 +1,25 @@
-{{#gh-token-input/select
-  renderInPlace=true
-  selected=selectedModule
-  options=modules
-  onchange=(action "setModule")
-  searchField="name"
-  as |module| }}
-  {{module.name}}
-{{/gh-token-input/select}}
-<br>
-{{#gh-token-input/select
-  disabled=(action "isModulePresent")
-  onchange=(action "setModule")
-  options=moduleOptions
-  renderInPlace=true
-  searchField="name"
-  selected=selectedRecord
-  as |record| }}
-  {{record}}
-{{/gh-token-input/select}}
+<b>{{examiningBoard.name}}</b>
+{{#gh-token-input/select-multiple
+class=(concat "gh-token-input " class)
+onchange=(action 'selectExaminingBoard')
+onopen=(action 'getExaminingBoards')
+options=examiningBoards
+renderInPlace=true
+searchField="sigla"
+selected=selectedExaminingBoards
+as |record| }}
+{{record.sigla}}
+{{/gh-token-input/select-multiple}}
+
+<b>{{institute.name}}</b>
+{{#gh-token-input/select-multiple
+class=(concat "gh-token-input " class)
+onchange=(action 'selectInstitute')
+onopen=(action 'getInstitutes')
+options=institutes
+renderInPlace=true
+searchField="sigla"
+selected=selectedInstitutes
+as |record| }}
+{{record.sigla}}
+{{/gh-token-input/select-multiple}}

--- a/app/templates/components/gh-psm-associations-input.hbs
+++ b/app/templates/components/gh-psm-associations-input.hbs
@@ -1,0 +1,20 @@
+{{#gh-token-input/select
+  renderInPlace=true
+  selected=selectedModule
+  options=modules
+  onchange=(action "setModule")
+  searchField="name"
+  as |module| }}
+  {{module.name}}
+{{/gh-token-input/select}}
+<br>
+{{#gh-token-input/select
+  disabled=(action "isModulePresent")
+  onchange=(action "setModule")
+  options=moduleOptions
+  renderInPlace=true
+  searchField="name"
+  selected=selectedRecord
+  as |record| }}
+  {{record}}
+{{/gh-token-input/select}}

--- a/package.json
+++ b/package.json
@@ -135,5 +135,8 @@
   },
   "resolutions": {
     "ember-in-viewport": "3.5.8"
+  },
+  "dependencies": {
+    "lodash": "^4.17.15"
   }
 }


### PR DESCRIPTION
Criar associações à modelos do Odin para posts do Ghost. Usando o [Brokk](https://github.com/qcx/brokk) eu pego os ids e alguns outros atributos dos recursos do Odin para exibição e seleção no próprio admin do Ghost.